### PR TITLE
ci: 添加 GitHub Actions 自动打包 VS Code 扩展

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,34 @@
+name: Package VS Code Extension
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Package extension
+        run: npx @vscode/vsce package --no-git-tag-version --no-update-package-json
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-vsix
+          path: '*.vsix'
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-mybatis-toolkit-pro-1.0.0.vsix
+*.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,8 @@
+.github/**
+.claude/**
+docs/**
+scripts/**
+*.vsix
 out/**
 src/**
 .gitignore


### PR DESCRIPTION
- 新增 .github/workflows/package.yml：推送/PR 到 main 时自动 npm ci + vsce package
- 产物 mybatis-toolkit-pro-*.vsix 作为 artifact 上传
- 优化 .vscodeignore，排除 .github/.claude/docs/scripts/*.vsix，减小扩展包体积
- .gitignore 统一忽略 *.vsix