### PR TITLE
feat: 新增 SQL Server、SQLite、DB2、H2 数据库适配器与元数据查询实现

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@
 - **资源释放**：`deactivate` 中现在正确释放数据库连接、索引器、SQL 验证器与文件监听器，避免扩展重载/卸载时资源泄漏。
 - **文件监听**：`ProjectIndexer` 维护 watcher 列表并提供 `dispose()`，重复激活不会累加监听器。
 - **未支持数据库类型**：`createDbAdapter` 对 SQL Server / SQLite / DB2 / H2 等未实现类型直接抛出明确错误，不再误用 MySQL 适配器执行。
+
+### 新增
+
+- **多数据库适配器**：新增 SQL Server、SQLite、DB2、H2 数据库连接与元数据查询适配器。
+  - SQL Server 使用 `mssql`（可选依赖），通过 `sys.tables` / `sys.columns` 查询表名、注释、列类型、主键、默认值。
+  - SQLite 使用 `better-sqlite3`（可选依赖），基于 `sqlite_master` 与 `PRAGMA table_info` 获取元数据。
+  - DB2 使用 `ibm_db`（可选依赖），通过 `SYSCAT.TABLES` / `SYSCAT.COLUMNS` 获取元数据。
+  - H2 使用 `jdbc`（可选依赖）+ H2 JDBC jar，通过 `INFORMATION_SCHEMA` 获取元数据；连接配置需指定 `options.jarPath`。
+- **可选数据库驱动 external**：`webpack.config.js` 中将上述可选驱动标记为 external，避免打包进 `extension.js`，按需动态加载。
+
 - **端口校验**：添加/编辑连接时校验端口为 1–65535 有效数字，避免 `NaN` 持久化到配置。
 - **同步 I/O 异步化**：「为方法生成 XML」命令使用 `fs.promises` 读写文件，避免阻塞扩展宿主。
 - **密码安全**：数据库密码迁移到 VS Code `SecretStorage`，不再明文写入 `settings.json`。

--- a/package.json
+++ b/package.json
@@ -518,6 +518,10 @@
     "pg": "^8.13.0"
   },
   "optionalDependencies": {
-    "oracledb": "^6.7.0"
+    "oracledb": "^6.7.0",
+    "mssql": "^11.0.1",
+    "better-sqlite3": "^12.0.0",
+    "ibm_db": "^3.2.4",
+    "jdbc": "^0.7.6"
   }
 }

--- a/src/services/db/Db2Adapter.ts
+++ b/src/services/db/Db2Adapter.ts
@@ -1,0 +1,116 @@
+import { ColumnInfo, ConnectionConfig, QueryResult } from '../../types';
+import { IDbAdapter } from './IDbAdapter';
+
+/** DB2 适配器（基于 ibm_db） */
+export class Db2Adapter implements IDbAdapter {
+    private conn: any;
+    private ibmdb: any;
+    private tableCache: Map<string, string> = new Map();
+    private schemaCache: Map<string, ColumnInfo[]> = new Map();
+
+    private async loadIbmDb(): Promise<any> {
+        if (this.ibmdb) return this.ibmdb;
+        try {
+            this.ibmdb = await import('ibm_db');
+            return this.ibmdb;
+        } catch {
+            throw new Error('请先安装 ibm_db 依赖: npm install ibm_db');
+        }
+    }
+
+    private buildConnStr(config: ConnectionConfig): string {
+        return `HOSTNAME=${config.host};PORT=${config.port};DATABASE=${config.database};UID=${config.user};PWD=${config.password};`;
+    }
+
+    async connect(config: ConnectionConfig): Promise<void> {
+        const ibmdb = await this.loadIbmDb();
+        this.conn = ibmdb.openSync(this.buildConnStr(config));
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.conn) {
+            this.conn.closeSync();
+            this.conn = undefined;
+        }
+        this.tableCache.clear();
+        this.schemaCache.clear();
+    }
+
+    async getTableNames(): Promise<string[]> {
+        if (!this.conn) return [];
+        const rows = this.conn.querySync("SELECT TABNAME FROM SYSCAT.TABLES WHERE TABSCHEMA = CURRENT_SCHEMA AND TYPE = 'T' ORDER BY TABNAME");
+        this.tableCache.clear();
+        const names: string[] = [];
+        for (const row of rows || []) {
+            const name = row.TABNAME;
+            names.push(name);
+            this.tableCache.set(name, '');
+        }
+        return names;
+    }
+
+    getTableComment(_tableName: string): string | undefined {
+        return '';
+    }
+
+    async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
+        if (!this.conn) return [];
+        if (this.schemaCache.has(tableName)) return this.schemaCache.get(tableName)!;
+        const rows = this.conn.querySync(
+            `SELECT COLNAME AS "Field",
+                    TYPENAME AS "Type",
+                    NULLS AS "Null",
+                    CASE WHEN KEYSEQ IS NOT NULL THEN 'PRI' ELSE '' END AS "Key",
+                    DEFAULT AS "Default",
+                    '' AS "Extra",
+                    REMARKS AS "Comment"
+             FROM SYSCAT.COLUMNS
+             WHERE TABNAME = ? AND TABSCHEMA = CURRENT_SCHEMA
+             ORDER BY COLNO`,
+            [tableName]
+        );
+        const columns: ColumnInfo[] = (rows || []).map((row: any) => ({
+            Field: row.Field,
+            Type: row.Type || '',
+            Null: row.Null,
+            Key: row.Key || '',
+            Default: row.Default,
+            Extra: row.Extra || '',
+            Comment: row.Comment || undefined
+        }));
+        this.schemaCache.set(tableName, columns);
+        return columns;
+    }
+
+    async getCreateTableStatement(tableName: string): Promise<string> {
+        if (!this.conn) return '';
+        const rows = this.conn.querySync('SELECT DDL FROM SYSCAT.TABLES WHERE TABNAME = ? AND TABSCHEMA = CURRENT_SCHEMA', [tableName]);
+        return rows?.[0]?.DDL || '';
+    }
+
+    async executeSql(sql: string, maxRows = 500): Promise<QueryResult> {
+        if (!this.conn) return { columns: [], rows: [], totalFetched: 0 };
+        const trimmed = sql.trim();
+        if (!trimmed) return { columns: [], rows: [], totalFetched: 0, message: '空语句' };
+        const start = Date.now();
+        try {
+            const rows = this.conn.querySync(trimmed);
+            const executionTimeMs = Date.now() - start;
+            if (!Array.isArray(rows)) {
+                return { columns: [], rows: [], totalFetched: 0, affectedRows: rows || 0, executionTimeMs };
+            }
+            const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+            const slice = rows.slice(0, maxRows);
+            const rowArrays = slice.map((row: any) => columns.map((c: string) => row[c] ?? null));
+            return {
+                columns,
+                rows: rowArrays,
+                totalFetched: slice.length,
+                executionTimeMs,
+                message: rows.length > maxRows ? `已截断，仅显示前 ${maxRows} 行（共 ${rows.length} 行）` : undefined
+            };
+        } catch (e: any) {
+            return { columns: [], rows: [], totalFetched: 0, message: e.message || String(e), executionTimeMs: Date.now() - start };
+        }
+    }
+}

--- a/src/services/db/H2Adapter.ts
+++ b/src/services/db/H2Adapter.ts
@@ -1,0 +1,228 @@
+import { ColumnInfo, ConnectionConfig, QueryResult } from '../../types';
+import { IDbAdapter } from './IDbAdapter';
+
+/**
+ * H2 适配器（基于 jdbc + H2 JDBC 驱动）。
+ * H2 是 Java 数据库，Node.js 没有原生驱动，因此需要：
+ * 1. 安装 jdbc 依赖：npm install jdbc
+ * 2. 下载 H2 JDBC jar（如 h2-2.2.224.jar）
+ * 3. 在连接配置的 options.jarPath 中指定 jar 路径
+ */
+export class H2Adapter implements IDbAdapter {
+    private pool: any;
+    private jdbc: any;
+    private jinst: any;
+    private tableCache: Map<string, string> = new Map();
+    private schemaCache: Map<string, ColumnInfo[]> = new Map();
+    private pkCache: Map<string, Set<string>> = new Map();
+
+    private async loadJdbc(): Promise<{ jdbc: any; jinst: any }> {
+        if (this.jdbc && this.jinst) return { jdbc: this.jdbc, jinst: this.jinst };
+        try {
+            this.jdbc = await import('jdbc');
+            this.jinst = await import('jdbc/lib/jinst');
+            return { jdbc: this.jdbc, jinst: this.jinst };
+        } catch {
+            throw new Error('请先安装 jdbc 依赖: npm install jdbc');
+        }
+    }
+
+    private setupClasspath(jinst: any, jarPath: string): void {
+        if (!jinst.isJvmCreated()) {
+            jinst.addOption('-Xrs');
+            jinst.setupClasspath([jarPath]);
+        }
+    }
+
+    async connect(config: ConnectionConfig): Promise<void> {
+        const { jdbc, jinst } = await this.loadJdbc();
+        const jarPath = (config as any).options?.jarPath;
+        if (!jarPath) {
+            throw new Error('H2 连接需要配置 options.jarPath（H2 JDBC jar 路径），例如 "./drivers/h2-2.2.224.jar"');
+        }
+        this.setupClasspath(jinst, jarPath);
+
+        const url = `jdbc:h2:tcp://${config.host}:${config.port}/${config.database}`;
+        const Pool = jdbc.default || jdbc;
+        this.pool = new Pool({
+            url,
+            drivername: 'org.h2.Driver',
+            minpoolsize: 1,
+            maxpoolsize: 5,
+            properties: {
+                user: config.user,
+                password: config.password
+            }
+        });
+        await this.initialize(this.pool);
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.pool) {
+            await this.purge(this.pool);
+            this.pool = undefined;
+        }
+        this.tableCache.clear();
+        this.schemaCache.clear();
+        this.pkCache.clear();
+    }
+
+    async getTableNames(): Promise<string[]> {
+        const rows = await this.query(
+            "SELECT TABLE_NAME, REMARKS FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA AND TABLE_TYPE = 'BASE TABLE' ORDER BY TABLE_NAME"
+        );
+        this.tableCache.clear();
+        this.pkCache.clear();
+        const names: string[] = [];
+        for (const row of rows) {
+            const name = row.TABLE_NAME;
+            names.push(name);
+            this.tableCache.set(name, row.REMARKS || '');
+        }
+        // 预加载主键信息
+        for (const name of names) {
+            const pks = await this.query(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_NAME = ? AND CONSTRAINT_NAME LIKE 'PRIMARY%' AND TABLE_SCHEMA = CURRENT_SCHEMA",
+                [name]
+            );
+            this.pkCache.set(name, new Set(pks.map((r: any) => r.COLUMN_NAME)));
+        }
+        return names;
+    }
+
+    getTableComment(tableName: string): string | undefined {
+        return this.tableCache.get(tableName);
+    }
+
+    async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
+        if (this.schemaCache.has(tableName)) return this.schemaCache.get(tableName)!;
+        const rows = await this.query(
+            `SELECT COLUMN_NAME AS "Field",
+                    TYPE_NAME AS "Type",
+                    IS_NULLABLE AS "Null",
+                    COLUMN_DEFAULT AS "Default",
+                    REMARKS AS "Comment",
+                    ORDINAL_POSITION AS "Pos"
+             FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_NAME = ? AND TABLE_SCHEMA = CURRENT_SCHEMA
+             ORDER BY ORDINAL_POSITION`,
+            [tableName]
+        );
+        const pkSet = this.pkCache.get(tableName) || new Set<string>();
+        const columns: ColumnInfo[] = rows.map((row: any) => ({
+            Field: row.Field,
+            Type: row.Type || '',
+            Null: row.Null,
+            Key: pkSet.has(row.Field) ? 'PRI' : '',
+            Default: row.Default,
+            Extra: '',
+            Comment: row.Comment || undefined
+        }));
+        this.schemaCache.set(tableName, columns);
+        return columns;
+    }
+
+    async getCreateTableStatement(tableName: string): Promise<string> {
+        const rows = await this.query(
+            'SELECT SQL FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = CURRENT_SCHEMA',
+            [tableName]
+        );
+        return rows[0]?.SQL || '';
+    }
+
+    async executeSql(sql: string, maxRows = 500): Promise<QueryResult> {
+        const trimmed = sql.trim();
+        if (!trimmed) return { columns: [], rows: [], totalFetched: 0, message: '空语句' };
+        const start = Date.now();
+        const conn = await this.reserve(this.pool);
+        try {
+            const statement = await this.createStatement(conn.conn);
+            const isSelect = /^\s*SELECT\s/i.test(trimmed);
+            if (isSelect) {
+                const rs = await this.executeQuery(statement, trimmed);
+                const rows = await this.toObjArray(rs);
+                const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+                const slice = rows.slice(0, maxRows);
+                const rowArrays = slice.map((row: any) => columns.map((c: string) => row[c] ?? null));
+                return {
+                    columns,
+                    rows: rowArrays,
+                    totalFetched: slice.length,
+                    executionTimeMs: Date.now() - start,
+                    message: rows.length > maxRows ? `已截断，仅显示前 ${maxRows} 行（共 ${rows.length} 行）` : undefined
+                };
+            } else {
+                const count = await this.executeUpdate(statement, trimmed);
+                return {
+                    columns: [],
+                    rows: [],
+                    totalFetched: 0,
+                    affectedRows: count,
+                    executionTimeMs: Date.now() - start
+                };
+            }
+        } catch (e: any) {
+            return { columns: [], rows: [], totalFetched: 0, message: e.message || String(e), executionTimeMs: Date.now() - start };
+        } finally {
+            await this.release(this.pool, conn);
+        }
+    }
+
+    // -------------- jdbc 回调 Promise 封装 --------------
+
+    private async query(sql: string, params?: any[]): Promise<any[]> {
+        if (!this.pool) return [];
+        const conn = await this.reserve(this.pool);
+        try {
+            let statement: any;
+            if (params && params.length > 0) {
+                const ps = await this.prepareStatement(conn.conn, sql);
+                params.forEach((p, i) => ps.setString(i + 1, p));
+                const rs = await this.executeQuery(ps, '');
+                return await this.toObjArray(rs);
+            } else {
+                statement = await this.createStatement(conn.conn);
+                const rs = await this.executeQuery(statement, sql);
+                return await this.toObjArray(rs);
+            }
+        } finally {
+            await this.release(this.pool, conn);
+        }
+    }
+
+    private initialize(pool: any): Promise<void> {
+        return new Promise((resolve, reject) => pool.initialize((err: any) => err ? reject(err) : resolve()));
+    }
+
+    private purge(pool: any): Promise<void> {
+        return new Promise((resolve) => pool.purge(() => resolve()));
+    }
+
+    private reserve(pool: any): Promise<any> {
+        return new Promise((resolve, reject) => pool.reserve((err: any, conn: any) => err ? reject(err) : resolve(conn)));
+    }
+
+    private release(pool: any, conn: any): Promise<void> {
+        return new Promise((resolve, reject) => pool.release(conn, (err: any) => err ? reject(err) : resolve()));
+    }
+
+    private createStatement(conn: any): Promise<any> {
+        return new Promise((resolve, reject) => conn.createStatement((err: any, stmt: any) => err ? reject(err) : resolve(stmt)));
+    }
+
+    private prepareStatement(conn: any, sql: string): Promise<any> {
+        return new Promise((resolve, reject) => conn.prepareStatement(sql, (err: any, stmt: any) => err ? reject(err) : resolve(stmt)));
+    }
+
+    private executeQuery(statement: any, sql: string): Promise<any> {
+        return new Promise((resolve, reject) => statement.executeQuery(sql, (err: any, rs: any) => err ? reject(err) : resolve(rs)));
+    }
+
+    private executeUpdate(statement: any, sql: string): Promise<number> {
+        return new Promise((resolve, reject) => statement.executeUpdate(sql, (err: any, count: any) => err ? reject(err) : resolve(count)));
+    }
+
+    private toObjArray(rs: any): Promise<any[]> {
+        return new Promise((resolve, reject) => rs.toObjArray((err: any, rows: any) => err ? reject(err) : resolve(rows || [])));
+    }
+}

--- a/src/services/db/SqlServerAdapter.ts
+++ b/src/services/db/SqlServerAdapter.ts
@@ -1,0 +1,150 @@
+import { ColumnInfo, ConnectionConfig, QueryResult } from '../../types';
+import { IDbAdapter } from './IDbAdapter';
+
+/** SQL Server 适配器（基于 mssql） */
+export class SqlServerAdapter implements IDbAdapter {
+    private pool: any;
+    private mssql: any;
+    private tableCache: Map<string, string> = new Map();
+    private schemaCache: Map<string, ColumnInfo[]> = new Map();
+
+    private async loadMssql(): Promise<any> {
+        if (this.mssql) return this.mssql;
+        try {
+            this.mssql = await import('mssql');
+            return this.mssql;
+        } catch {
+            throw new Error('请先安装 mssql 依赖: npm install mssql');
+        }
+    }
+
+    async connect(config: ConnectionConfig): Promise<void> {
+        const mssql = await this.loadMssql();
+        this.pool = new mssql.ConnectionPool({
+            server: config.host,
+            port: config.port,
+            user: config.user,
+            password: config.password,
+            database: config.database,
+            options: {
+                trustServerCertificate: true,
+                encrypt: false
+            }
+        });
+        await this.pool.connect();
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.pool) {
+            await this.pool.close();
+            this.pool = undefined;
+        }
+        this.tableCache.clear();
+        this.schemaCache.clear();
+    }
+
+    async getTableNames(): Promise<string[]> {
+        if (!this.pool) return [];
+        const result = await this.pool.request().query(`
+            SELECT t.name AS table_name, ep.value AS comment
+            FROM sys.tables t
+            LEFT JOIN sys.extended_properties ep ON ep.major_id = t.object_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
+            ORDER BY t.name
+        `);
+        this.tableCache.clear();
+        const names: string[] = [];
+        for (const row of result.recordset || []) {
+            names.push(row.table_name);
+            this.tableCache.set(row.table_name, row.comment || '');
+        }
+        return names;
+    }
+
+    getTableComment(tableName: string): string | undefined {
+        return this.tableCache.get(tableName);
+    }
+
+    async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
+        if (!this.pool) return [];
+        if (this.schemaCache.has(tableName)) return this.schemaCache.get(tableName)!;
+        const result = await this.pool.request()
+            .input('tableName', tableName)
+            .query(`
+                SELECT
+                    c.name AS "Field",
+                    tp.name + CASE
+                        WHEN tp.name IN ('varchar', 'nvarchar', 'char', 'nchar', 'varbinary')
+                            THEN '(' + CASE WHEN c.max_length = -1 THEN 'MAX' ELSE CAST(c.max_length AS VARCHAR) END + ')'
+                        WHEN tp.name IN ('decimal', 'numeric')
+                            THEN '(' + CAST(c.precision AS VARCHAR) + ',' + CAST(c.scale AS VARCHAR) + ')'
+                        ELSE ''
+                    END AS "Type",
+                    CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS "Null",
+                    CASE WHEN i.is_primary_key = 1 THEN 'PRI' ELSE '' END AS "Key",
+                    dc.definition AS "Default",
+                    '' AS "Extra",
+                    ep.value AS "Comment"
+                FROM sys.columns c
+                INNER JOIN sys.types tp ON c.user_type_id = tp.user_type_id
+                LEFT JOIN sys.index_columns ic ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+                LEFT JOIN sys.indexes i ON i.object_id = ic.object_id AND i.index_id = ic.index_id AND i.is_primary_key = 1
+                LEFT JOIN sys.default_constraints dc ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+                LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id AND ep.minor_id = c.column_id AND ep.name = 'MS_Description'
+                WHERE OBJECT_NAME(c.object_id) = @tableName
+                ORDER BY c.column_id
+            `);
+        const columns: ColumnInfo[] = (result.recordset || []).map((row: any) => ({
+            Field: row.Field,
+            Type: row.Type || '',
+            Null: row.Null,
+            Key: row.Key || '',
+            Default: row.Default,
+            Extra: row.Extra || '',
+            Comment: row.Comment || undefined
+        }));
+        this.schemaCache.set(tableName, columns);
+        return columns;
+    }
+
+    async getCreateTableStatement(tableName: string): Promise<string> {
+        if (!this.pool) return '';
+        const result = await this.pool.request()
+            .input('tableName', tableName)
+            .query('SELECT OBJECT_DEFINITION(OBJECT_ID(@tableName)) AS sql');
+        return result.recordset?.[0]?.sql || '';
+    }
+
+    async executeSql(sql: string, maxRows = 500): Promise<QueryResult> {
+        if (!this.pool) return { columns: [], rows: [], totalFetched: 0 };
+        const trimmed = sql.trim();
+        if (!trimmed) return { columns: [], rows: [], totalFetched: 0, message: '空语句' };
+        const start = Date.now();
+        try {
+            const result = await this.pool.request().query(trimmed);
+            const executionTimeMs = Date.now() - start;
+            const rows = result.recordset || [];
+            const rowsAffected = result.rowsAffected?.[0];
+            if (typeof rowsAffected === 'number' && rows.length === 0) {
+                return {
+                    columns: [],
+                    rows: [],
+                    totalFetched: 0,
+                    affectedRows: rowsAffected,
+                    executionTimeMs
+                };
+            }
+            const columns = rows.length > 0 ? Object.keys(rows[0]) : (result.recordsets?.[0]?.columns || []);
+            const slice = rows.slice(0, maxRows);
+            const rowArrays = slice.map((row: any) => columns.map((c: string) => row[c] ?? null));
+            return {
+                columns,
+                rows: rowArrays,
+                totalFetched: slice.length,
+                executionTimeMs,
+                message: rows.length > maxRows ? `已截断，仅显示前 ${maxRows} 行（共 ${rows.length} 行）` : undefined
+            };
+        } catch (e: any) {
+            return { columns: [], rows: [], totalFetched: 0, message: e.message || String(e), executionTimeMs: Date.now() - start };
+        }
+    }
+}

--- a/src/services/db/SqliteAdapter.ts
+++ b/src/services/db/SqliteAdapter.ts
@@ -1,0 +1,111 @@
+import { ColumnInfo, ConnectionConfig, QueryResult } from '../../types';
+import { IDbAdapter } from './IDbAdapter';
+
+/** SQLite 适配器（基于 better-sqlite3） */
+export class SqliteAdapter implements IDbAdapter {
+    private db: any;
+    private sqlite: any;
+    private tableCache: Map<string, string> = new Map();
+    private schemaCache: Map<string, ColumnInfo[]> = new Map();
+
+    private async loadSqlite(): Promise<any> {
+        if (this.sqlite) return this.sqlite;
+        try {
+            this.sqlite = await import('better-sqlite3');
+            return this.sqlite;
+        } catch {
+            throw new Error('请先安装 better-sqlite3 依赖: npm install better-sqlite3');
+        }
+    }
+
+    async connect(config: ConnectionConfig): Promise<void> {
+        const sqlite = await this.loadSqlite();
+        // database 字段作为文件路径；为空时使用内存数据库
+        const path = config.database || ':memory:';
+        this.db = new sqlite.default(path);
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.db) {
+            this.db.close();
+            this.db = undefined;
+        }
+        this.tableCache.clear();
+        this.schemaCache.clear();
+    }
+
+    async getTableNames(): Promise<string[]> {
+        if (!this.db) return [];
+        const rows = this.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name").all();
+        this.tableCache.clear();
+        const names: string[] = [];
+        for (const row of rows) {
+            names.push(row.name);
+            this.tableCache.set(row.name, '');
+        }
+        return names;
+    }
+
+    getTableComment(_tableName: string): string | undefined {
+        // SQLite 原生不支持表注释
+        return '';
+    }
+
+    async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
+        if (!this.db) return [];
+        if (this.schemaCache.has(tableName)) return this.schemaCache.get(tableName)!;
+        const rows = this.db.prepare(`PRAGMA table_info("${tableName.replace(/"/g, '""')}")`).all();
+        const columns: ColumnInfo[] = rows.map((row: any) => ({
+            Field: row.name,
+            Type: row.type || '',
+            Null: row.notnull ? 'NO' : 'YES',
+            Key: row.pk ? 'PRI' : '',
+            Default: row.dflt_value ?? null,
+            Extra: '',
+            Comment: undefined
+        }));
+        this.schemaCache.set(tableName, columns);
+        return columns;
+    }
+
+    async getCreateTableStatement(tableName: string): Promise<string> {
+        if (!this.db) return '';
+        const row = this.db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(tableName);
+        return row?.sql || '';
+    }
+
+    async executeSql(sql: string, maxRows = 500): Promise<QueryResult> {
+        if (!this.db) return { columns: [], rows: [], totalFetched: 0 };
+        const trimmed = sql.trim();
+        if (!trimmed) return { columns: [], rows: [], totalFetched: 0, message: '空语句' };
+        const start = Date.now();
+        try {
+            const stmt = this.db.prepare(trimmed);
+            const isSelect = /^\s*SELECT\s/i.test(trimmed);
+            if (isSelect) {
+                const rows = stmt.all();
+                const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+                const slice = rows.slice(0, maxRows);
+                const rowArrays = slice.map((row: any) => columns.map((c: string) => row[c] ?? null));
+                return {
+                    columns,
+                    rows: rowArrays,
+                    totalFetched: slice.length,
+                    executionTimeMs: Date.now() - start,
+                    message: rows.length > maxRows ? `已截断，仅显示前 ${maxRows} 行（共 ${rows.length} 行）` : undefined
+                };
+            } else {
+                const result = stmt.run();
+                return {
+                    columns: [],
+                    rows: [],
+                    totalFetched: 0,
+                    affectedRows: result.changes,
+                    executionTimeMs: Date.now() - start
+                };
+            }
+        } catch (e: any) {
+            return { columns: [], rows: [], totalFetched: 0, message: e.message || String(e), executionTimeMs: Date.now() - start };
+        }
+    }
+}

--- a/src/services/db/global.d.ts
+++ b/src/services/db/global.d.ts
@@ -1,0 +1,6 @@
+// 可选数据库驱动，运行时动态加载；声明为 any 避免未安装时 TypeScript 报错
+declare module 'mssql';
+declare module 'better-sqlite3';
+declare module 'ibm_db';
+declare module 'jdbc';
+declare module 'jdbc/lib/jinst';

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -3,6 +3,10 @@ import { IDbAdapter } from './IDbAdapter';
 import { MySQLAdapter } from './MySQLAdapter';
 import { PgAdapter } from './PgAdapter';
 import { OracleAdapter } from './OracleAdapter';
+import { SqlServerAdapter } from './SqlServerAdapter';
+import { SqliteAdapter } from './SqliteAdapter';
+import { Db2Adapter } from './Db2Adapter';
+import { H2Adapter } from './H2Adapter';
 
 export function createDbAdapter(config: ConnectionConfig): IDbAdapter {
     switch (config.type) {
@@ -14,10 +18,13 @@ export function createDbAdapter(config: ConnectionConfig): IDbAdapter {
         case 'MariaDB':
             return new MySQLAdapter();
         case 'SQL Server':
+            return new SqlServerAdapter();
         case 'SQLite':
+            return new SqliteAdapter();
         case 'DB2':
+            return new Db2Adapter();
         case 'H2':
-            throw new Error(`数据库类型 "${config.type}" 尚未支持连接与元数据查询。`);
+            return new H2Adapter();
         default:
             throw new Error(`未知的数据库类型: ${config.type}`);
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,10 +30,13 @@ module.exports = {
         ]
     },
     externals: {
-        vscode: 'commonjs vscode', // Ignored because it's provided by the VS Code host
-        // mysql2 might have optional dependencies like 'aws-crt' which cause warnings if not present.
-        // We can mark them as external if they cause issues, or let webpack handle them.
-        // For now, let's try bundling mysql2.
+        vscode: 'commonjs vscode',
+        // 可选数据库驱动按运行时动态加载，不参与打包
+        mssql: 'commonjs mssql',
+        'better-sqlite3': 'commonjs better-sqlite3',
+        'ibm_db': 'commonjs ibm_db',
+        jdbc: 'commonjs jdbc',
+        'jdbc/lib/jinst': 'commonjs jdbc/lib/jinst'
     },
     performance: {
         hints: false


### PR DESCRIPTION
- 新增 SqlServerAdapter（基于 mssql）、SqliteAdapter（基于 better-sqlite3）、Db2Adapter（基于 ibm_db）、H2Adapter（基于 jdbc + H2 JDBC jar）
- 各适配器实现 connect/disconnect、getTableNames、getTableSchema、getCreateTableStatement、executeSql
- createDbAdapter 根据配置类型分发到对应适配器，不再抛出未支持错误
- package.json optionalDependencies 增加 mssql、better-sqlite3、ibm_db、jdbc
- webpack.config.js 将可选数据库驱动标记为 external，避免打包进 extension.js
- 更新 CHANGELOG